### PR TITLE
FIX:javadoc "错误: 编码GBK的不可映射字符"

### DIFF
--- a/AndResGuard-cli/build.gradle
+++ b/AndResGuard-cli/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 
 Properties properties = new Properties()
 try {

--- a/AndResGuard-core/build.gradle
+++ b/AndResGuard-core/build.gradle
@@ -13,7 +13,7 @@ version = properties.getProperty("bintray.version")
 group = properties.getProperty("bintray.groupId")
 def appId = 'AndResGuard-core'
 
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }


### PR DESCRIPTION
\AndResGuard\AndResGuard-core\src\main\java\com\tencent\mm\util\Utils.
java:31: 错误: 编码GBK的不可映射字符