### PR TITLE
优化buildApk.bat的使用示例

### DIFF
--- a/tool_output/buildApk.bat
+++ b/tool_output/buildApk.bat
@@ -1,2 +1,8 @@
-java -jar AndResGuard-cli-1.1.0.jar input.apk -config config.xml -out outapk -signature release.keystore testres testres testres
+set jdkpath=D:\Program Files\Java\jdk1.7.0_79\bin\java.exe
+set storepath=release.keystore
+set storepass=testres
+set keypass=testres
+set alias=testres
+set zipalign=D:\soft\dev\android\sdk\build-tools\23.0.2\zipalign.exe
+"%jdkpath%" -jar AndResGuard-cli-1.1.0.jar input.apk -config config.xml -out outapk -signature "%storepath%" "%storepass%" "%keypass%" "%alias%" -zipalign "%zipalign%"
 pause


### PR DESCRIPTION
1、解决电脑安装了jdk6无法运行的问题，需要指定jdk7以上路径。
2、解决了原示例中如果不带有zipalign会报错。并且提示的zipalign和后面的路径需要有空格。这个提示只能在jar中修改了。。
3、全部做成了声明形式，方便大家调用吧。