### PR TITLE
Make jarsigner support SHA1withDSA, SHA256withRSA, or SHA256withECDSA.

### DIFF
--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/ResourceApkBuilder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/ResourceApkBuilder.java
@@ -105,7 +105,7 @@ public class ResourceApkBuilder {
                 mSignedApk.delete();
             }
             String[] argv = {
-                "jarsigner", "-sigalg", "MD5withRSA",
+                "jarsigner",
                 "-digestalg", "SHA1",
                 "-keystore", config.mSignatureFile.getAbsolutePath(),
                 "-storepass", config.mStorePass,


### PR DESCRIPTION
http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html

-sigalg algorithm: If this option is not specified, then SHA1withDSA, SHA256withRSA, or SHA256withECDSA are used depending on the type of private key.