### PR TITLE
Fix arsc decoder for wrong chunk header read and table config size 64 processing

### DIFF
--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
@@ -44,7 +44,7 @@ public class RawARSCDecoder {
     private final static short ENTRY_FLAG_WEAK = 0x0004;
 
     private static final Logger LOGGER             = Logger.getLogger(ARSCDecoder.class.getName());
-    private static final int    KNOWN_CONFIG_BYTES = 56;
+    private static final int    KNOWN_CONFIG_BYTES = 64;
 
     private static HashMap<Integer, Set<String>> mExistTypeNames;
 
@@ -299,6 +299,11 @@ public class RawARSCDecoder {
             read = 56;
         }
 
+        if (size >= 64) {
+            mIn.skipBytes(8);
+            read = 64;
+        }
+
         int exceedingSize = size - KNOWN_CONFIG_BYTES;
         if (exceedingSize > 0) {
             byte[] buf = new byte[exceedingSize];
@@ -315,10 +320,11 @@ public class RawARSCDecoder {
                 ));
                 isInvalid = true;
             }
-        }
-        int remainingSize = size - read;
-        if (remainingSize > 0) {
-            mIn.skipBytes(remainingSize);
+        } else {
+            int remainingSize = size - read;
+            if (remainingSize > 0) {
+                mIn.skipBytes(remainingSize);
+            }
         }
     }
 

--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
@@ -138,18 +138,24 @@ public class RawARSCDecoder {
             System.out.printf("Decoding Shared Library (%s), pkgId: %d\n", packageName, packageId);
         }
 
-        while(nextChunk().type == Header.TYPE_TYPE) {
+        nextChunk();
+        while(mHeader.type == Header.TYPE_TYPE) {
             readTableTypeSpec();
         }
     }
 
     private void readTableTypeSpec() throws AndrolibException, IOException {
         readSingleTableTypeSpec();
-        while (nextChunk().type == Header.TYPE_SPEC_TYPE) {
+
+        nextChunk();
+        while (mHeader.type == Header.TYPE_SPEC_TYPE) {
             readSingleTableTypeSpec();
+            nextChunk();
         }
-        while (nextChunk().type == Header.TYPE_TYPE) {
+
+        while (mHeader.type == Header.TYPE_TYPE) {
             readConfig();
+            nextChunk();
         }
     }
 
@@ -160,6 +166,10 @@ public class RawARSCDecoder {
         int entryCount = mIn.readInt();
 
         /* flags */mIn.skipBytes(entryCount * 4);
+
+        mCurTypeID = id;
+        mResId = (0xff000000 & mResId) | id << 16;
+        mType = new ResType(mTypeNames.getString(id - 1), mPkg);
     }
 
     private void readConfig() throws IOException, AndrolibException {


### PR DESCRIPTION
commit [b7aaa4c](https://github.com/shwenzhang/AndResGuard/commit/b7aaa4cc29706f87ff8dab591b09942e8238cf4f)  has broken the original arsc decoder and makes `readConfig()` method will never be called and `mExistingTypeNames` becomes empty. And it still not work with the arsc generated by Android P's build-tools for example 28.0.2

Bug 1: In method `readTableTypeSpec()`, if the `nextChunk().type != Header.TYPE_SPEC_TYPE` in while block, the `nextChunk()` in next while block will consume the wrong bytes and make the condition not match. 
Meanwhile, mCurTypeID should be set to right value in `readSingleTableTypeSpec()`, because it is the key for `mExistingTypeNames` and will used later in `readEntry()`.


Bug 2: the arsc file generated by Android P' build-tools, the table-config size have become to 64, but the `readConfigFlags()` not handle well. 

[#L295](https://github.com/shwenzhang/AndResGuard/blob/master/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java#L295) in RawARSCDecoder has already read the remaining bytes but [#L311](https://github.com/shwenzhang/AndResGuard/blob/master/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java#L311) still try to skip the remains bytes, so it goto wrong offset.

So I change `KNOWN_CONFIG_BYTES` to 64 and move the remainingSize logic to else block to prevent reading twice.

