### PR TITLE
Update white_list.md

### DIFF
--- a/doc/white_list.md
+++ b/doc/white_list.md
@@ -60,5 +60,20 @@ R.string.project_id
 
 ### Huawei push
 ```
-R.string.hms_update_title
+"R.string.hms_*",
+"R.string.connect_server_fail_prompt_toast",
+"R.string.getting_message_fail_prompt_toast",
+"R.string.no_available_network_prompt_toast",
+"R.string.third_app_*",
+"R.string.upsdk_*",
+"R.style.upsdkDlDialog",
+"R.style.AppTheme",
+"R.style.AppBaseTheme",
+"R.dimen.upsdk_dialog_*",
+"R.color.upsdk_*",
+"R.layout.upsdk_*",
+"R.drawable.upsdk_*",
+"R.drawable.hms_*",
+"R.layout.hms_*",
+"R.id.hms_*"
 ```


### PR DESCRIPTION
fix Huawei push white list
will be crash without Huawei push white list when the version of Huawei Mobile Services is too old.
more detail >>> https://blog.csdn.net/scau_zhangpeng/article/details/93909530