### PR TITLE
[feat] make arsc name column to a fixed value to reduce string pool size

### DIFF
--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/data/ResPackage.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/data/ResPackage.java
@@ -20,18 +20,19 @@ package com.tencent.mm.androlib.res.data;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class ResPackage {
   private final String mName;
 
   private final Map<Integer, String> mSpecNamesReplace;
-  private final HashSet<String> mSpecNamesBlock;
+  private final Map<String, Set<String>> mSpecNamesBlock;
   private boolean mCanProguard = false;
 
   public ResPackage(int id, String name) {
     this.mName = name;
     mSpecNamesReplace = new LinkedHashMap<>();
-    mSpecNamesBlock = new HashSet<>();
+    mSpecNamesBlock = new LinkedHashMap<>();
   }
 
   public boolean isCanResguard() {
@@ -54,11 +55,16 @@ public class ResPackage {
     mSpecNamesReplace.put(resID, value);
   }
 
-  public void putSpecNamesblock(String value) {
-    mSpecNamesBlock.add(value);
+  public void putSpecNamesblock(String specName, String value) {
+    Set<String> values = mSpecNamesBlock.get(specName);
+    if (values == null) {
+      values = new HashSet<>();
+      mSpecNamesBlock.put(specName, values);
+    }
+    values.add(value);
   }
 
-  public HashSet<String> getSpecNamesBlock() {
+  public Map<String, Set<String>> getSpecNamesBlock() {
     return mSpecNamesBlock;
   }
 

--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/ARSCDecoder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/ARSCDecoder.java
@@ -608,7 +608,7 @@ public class ARSCDecoder {
               System.out.printf("[match] matcher %s ,typeName %s, specName :%s\n", p.pattern(), typeName, specName);
             }
             mPkg.putSpecNamesReplace(mResId, specName);
-            mPkg.putSpecNamesblock(specName);
+            mPkg.putSpecNamesblock(specName, specName);
             mResguardBuilder.setInWhiteList(mCurEntryID);
 
             mType.putSpecResguardName(specName);
@@ -649,7 +649,10 @@ public class ARSCDecoder {
     }
     generalResIDMapping(mPkg.getName(), mType.getName(), mSpecNames.get(specNamesId).toString(), replaceString);
     mPkg.putSpecNamesReplace(mResId, replaceString);
-    mPkg.putSpecNamesblock(replaceString);
+    // arsc name列混淆成固定名字, 减少string pool大小
+    boolean useFixedName = config.mFixedResName != null && config.mFixedResName.length() > 0;
+    String fixedName = useFixedName ? config.mFixedResName : replaceString;
+    mPkg.putSpecNamesblock(fixedName, replaceString);
     mType.putSpecResguardName(replaceString);
   }
 

--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/StringBlock.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/StringBlock.java
@@ -26,9 +26,9 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -104,7 +104,7 @@ public class StringBlock {
   }
 
   public static int writeSpecNameStringBlock(
-      ExtDataInput reader, ExtDataOutput out, HashSet<String> specNames, Map<String, Integer> curSpecNameToPos)
+          ExtDataInput reader, ExtDataOutput out, Map<String, Set<String>> specNames, Map<String, Integer> curSpecNameToPos)
       throws IOException, AndrolibException {
     int type = reader.readInt();
     int chunkSize = reader.readInt();
@@ -132,7 +132,8 @@ public class StringBlock {
     int totalSize = 0;
     out.writeCheckInt(type, CHUNK_STRINGPOOL_TYPE);
     totalSize += 4;
-    stringCount = specNames.size();
+    stringCount = specNames.keySet().size();
+    System.out.println("String pool size: " + stringCount);
 
     totalSize += 6 * 4 + 4 * stringCount;
     stringsOffset = totalSize;
@@ -144,10 +145,13 @@ public class StringBlock {
     int i = 0;
     curSpecNameToPos.clear();
 
-    for (Iterator<String> it = specNames.iterator(); it.hasNext(); ) {
+    for (Iterator<String> it = specNames.keySet().iterator(); it.hasNext(); ) {
       stringOffsets[i] = offset;
       String name = it.next();
-      curSpecNameToPos.put(name, i);
+      for (String specName : specNames.get(name)) {
+        // N res entry item point to one string constant
+        curSpecNameToPos.put(specName, i);
+      }
       if (isUTF8) {
         stringBytes[offset++] = (byte) name.length();
         stringBytes[offset++] = (byte) name.length();

--- a/AndResGuard-core/src/main/java/com/tencent/mm/resourceproguard/Configuration.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/resourceproguard/Configuration.java
@@ -56,6 +56,7 @@ public class Configuration {
   public boolean mKeepRoot = false;
   public boolean mMergeDuplicatedRes = false;
   public String mMetaName = "META-INF";
+  public String mFixedResName = null;
   public boolean mUseSignAPK = false;
   public boolean mUseKeepMapping = false;
   public File mSignatureFile;
@@ -136,6 +137,7 @@ public class Configuration {
     mKeepRoot = param.keepRoot;
     mMergeDuplicatedRes = param.mergeDuplicatedRes;
     mMetaName = param.metaName;
+    mFixedResName = param.fixedResName;
     for (String item : param.compressFilePattern) {
       mUseCompress = true;
       addToCompressPatterns(item);

--- a/AndResGuard-core/src/main/java/com/tencent/mm/resourceproguard/InputParam.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/resourceproguard/InputParam.java
@@ -11,6 +11,7 @@ public class InputParam {
   public final boolean mergeDuplicatedRes;
   public final boolean useSign;
   public final String metaName;
+  public final String fixedResName;
   public final ArrayList<String> whiteList;
   public final ArrayList<String> compressFilePattern;
   public final String apkPath;
@@ -41,6 +42,7 @@ public class InputParam {
       String storealias,
       String storepass,
       String metaName,
+      String fixedResName,
       String zipAlignPath,
       String sevenZipPath,
       SignatureType signatureType,
@@ -62,6 +64,7 @@ public class InputParam {
     this.storealias = storealias;
     this.storepass = storepass;
     this.metaName = metaName;
+    this.fixedResName = fixedResName;
     this.zipAlignPath = zipAlignPath;
     this.sevenZipPath = sevenZipPath;
     this.signatureType = signatureType;
@@ -89,6 +92,7 @@ public class InputParam {
     private String storealias;
     private String storepass;
     private String metaName;
+    private String fixedResName;
     private String zipAlignPath;
     private String sevenZipPath;
     private SignatureType signatureType;
@@ -175,6 +179,11 @@ public class InputParam {
       return this;
     }
 
+    public Builder setFixedResName(String fixedResName) {
+      this.fixedResName = fixedResName;
+      return this;
+    }
+
     public Builder setZipAlign(String zipAlignPath) {
       this.zipAlignPath = zipAlignPath;
       return this;
@@ -225,6 +234,7 @@ public class InputParam {
           storealias,
           storepass,
           metaName,
+          fixedResName,
           zipAlignPath,
           sevenZipPath,
           signatureType,

--- a/AndResGuard-gradle-plugin/src/main/groovy/com/tencent/gradle/AndResGuardExtension.groovy
+++ b/AndResGuard-gradle-plugin/src/main/groovy/com/tencent/gradle/AndResGuardExtension.groovy
@@ -12,6 +12,7 @@ class AndResGuardExtension {
   boolean use7zip
   boolean useSign
   String metaName
+  String fixedResName
   boolean keepRoot
   boolean mergeDuplicatedRes
   Iterable<String> whiteList
@@ -26,6 +27,7 @@ class AndResGuardExtension {
     use7zip = false
     useSign = false
     metaName = "META-INF"
+    fixedResName = null
     keepRoot = false
     mergeDuplicatedRes = false
     whiteList = []
@@ -56,6 +58,10 @@ class AndResGuardExtension {
 
   String getMetaName() {
     return metaName
+  }
+
+  String getFixedResName() {
+    return fixedResName
   }
 
   boolean getKeepRoot() {
@@ -95,6 +101,7 @@ class AndResGuardExtension {
     """| use7zip = ${use7zip}
            | useSign = ${useSign}
            | metaName = ${metaName}
+           | fixedResName = ${fixedResName}
            | keepRoot = ${keepRoot}
            | mergeDuplicatedRes = ${mergeDuplicatedRes}
            | whiteList = ${whiteList}

--- a/AndResGuard-gradle-plugin/src/main/groovy/com/tencent/gradle/AndResGuardTask.groovy
+++ b/AndResGuard-gradle-plugin/src/main/groovy/com/tencent/gradle/AndResGuardTask.groovy
@@ -134,6 +134,7 @@ class AndResGuardTask extends DefaultTask {
         .setWhiteList(whiteListFullName)
         .setUse7zip(configuration.use7zip)
         .setMetaName(configuration.metaName)
+        .setFixedResName(configuration.fixedResName)
         .setKeepRoot(configuration.keepRoot)
         .setMergeDuplicatedRes(configuration.mergeDuplicatedRes)
         .setCompressFilePattern(configuration.compressFilePattern)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ andResGuard {
     useSign = true
     // It will keep the origin path of your resources when it's true
     keepRoot = false
+    // If set, name column in arsc those need to proguard will be kept to this value
+    fixedResName = "tencent"
     // It will merge the duplicated resources, but don't rely on this feature too much.
     // it's always better to remove duplicated resource from repo
     mergeDuplicatedRes = true

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -37,6 +37,8 @@ andResGuard {
     useSign = true
     // 打开这个开关，会keep住所有资源的原始路径，只混淆资源的名字
     keepRoot = false
+    // 设置这个值，会把arsc name列混淆成相同的名字，减少string常量池的大小
+    fixedResName = "tencent"
     // 打开这个开关会合并所有哈希值相同的资源，但请不要过度依赖这个功能去除去冗余资源
     mergeDuplicatedRes = true
     whiteList = [


### PR DESCRIPTION
After AndRes proguard, the name column of arsc will be useless and java code won't access it by getIdentify() anymore, so we can proguard those values to a fixed short name than random value to reduce string pool size.
random value: 32 (a-z) + 2 * 46 * 46 (0-9a-z) + ....  more resources more bytes 
fixed value : N(small) size,  it won't increase with more resources

As pictures show below, mobile qq has implementation same effect and works well. And I modify some code to support this feature and apply to our product. It reduces about 100~200KB of resources.arsc file and works fine.
<img width="798" alt="WX20190630-160451@2x" src="https://user-images.githubusercontent.com/5836221/60395593-5e268e80-9b68-11e9-9579-d3068d790e24.png">