### PR TITLE
add shareSDK to Update white_list.md

### DIFF
--- a/doc/white_list.md
+++ b/doc/white_list.md
@@ -77,3 +77,18 @@ R.string.project_id
 "R.layout.hms_*",
 "R.id.hms_*"
 ```
+
+### shareSDK
+ 
+```
+"R.id.ssdk*",
+"R.string.mobcommon*",
+"R.string.ssdk*",
+"R.string.mobdemo*",
+"R.drawable.mobcommon*",
+"R.drawable.ssdk*",
+"R.layout.mob*",
+"R.style.mobcommon*",
+        
+```
+


### PR DESCRIPTION
shareSDK 中也是用了 getIdentifier 获取资源，具体为 com.mob.tools.utils.ResHelper 。使用位置 为 cn.sharesdk.framework.ProvicyCanContinue 。 如果不 添加白名单会导致 分享不成功，而且 shareSDK 内部 关闭的 log，导致 没有调试信息输出，排查难度较大。