### PR TITLE
[fix] add firebase required resource to whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ andResGuard {
         "R.string.ga_trackingId",
         "R.string.firebase_database_url",
         "R.string.google_api_key",
-        "R.string.google_crash_reporting_api_key"
+        "R.string.google_crash_reporting_api_key",
+        "R.string.project_id",
     ]
     compressFilePattern = [
         "*.png",


### PR DESCRIPTION
Project will be crash after launch every time without"R.string.project_id" string, 
project_id is required for Firebase SDK integration