### PR TITLE
fix(core):  fix AndResGuard error when containing multiple Dynamic Feature modules, support AAB package format #462

### DIFF
--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/RawARSCDecoder.java
@@ -117,11 +117,13 @@ public class RawARSCDecoder {
     mResId = id << 24;
     mPkg = new ResPackage(id, name);
     nextChunk();
-    while (mHeader.type == Header.TYPE_LIBRARY) {
-      readLibraryType();
-    }
-    while (mHeader.type == Header.TYPE_SPEC_TYPE) {
-      readTableTypeSpec();
+    while (mHeader.type == ARSCDecoder.Header.TYPE_LIBRARY || mHeader.type == ARSCDecoder.Header.TYPE_SPEC_TYPE) {
+      if (mHeader.type == ARSCDecoder.Header.TYPE_LIBRARY) {
+        readLibraryType();
+      }
+      if (mHeader.type == ARSCDecoder.Header.TYPE_SPEC_TYPE) {
+        readTableTypeSpec();
+      }
     }
 
     return mPkg;


### PR DESCRIPTION


PROBLEM DESCRIPTION: In an Android application that contains multiple Dynamic Feature modules, AndResGuard will report an error, corresponding to the error stack:

PROBLEM ANALYSIS: By analyzing the resources.arsc binary file, it is found that in the binary block
of the chunk type of RES_TABLE_TYPE of the ordinary application, the data distribution first exists
in TYPE_LIBRARY, and then there is the data block of TYPE_SPEC_TYPE.
In applications that include Dynamic Feature, TYPE_LIBRARY data blocks and TYPE_SPEC_TYPE data blocks
will alternate, and the existing chunk parsing logic will throw an exception.

FIX PLAN: rewrite the parsing logic of TYPE_LIBRARY, TYPE_SPEC_TYPE data blocks into the form of
a while loop to support the scene where two types of data blocks are mixed

VERIFICATION SITUATION: The resource confusion is normal, and it has been running normally on
the mobile QQ pipeline for a long time, and the release version is also running stable

close #462