### PR TITLE
fix macbook m1 aarch64-jdk sync error

### DIFF
--- a/SevenZip/build.gradle
+++ b/SevenZip/build.gradle
@@ -46,6 +46,10 @@ publishing {
         classifier "osx-x86_64"
         extension "exe"
       }
+      artifact("executable/SevenZip-osx-aarch_64.exe") {
+        classifier "osx-aarch_64"
+        extension "exe"
+      }
     }
   }
 }


### PR DESCRIPTION
SevenZip-osx-aarch_64.exe from https://www.7-zip.org/a/7z2103-mac.tar.xz