### PR TITLE
[fix] fix Could not decode arsc file build error (#450)

### DIFF
--- a/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/ARSCDecoder.java
+++ b/AndResGuard-core/src/main/java/com/tencent/mm/androlib/res/decoder/ARSCDecoder.java
@@ -360,6 +360,9 @@ public class ARSCDecoder {
     while (mHeader.type == Header.TYPE_SPEC_TYPE) {
       readTableTypeSpec();
     }
+    while (mHeader.type == Header.TYPE_LIBRARY) {
+      readLibraryType();
+    }
     return mPkg;
   }
 
@@ -397,6 +400,9 @@ public class ARSCDecoder {
     }
     while (mHeader.type == Header.TYPE_SPEC_TYPE) {
       writeTableTypeSpec();
+    }
+    while (mHeader.type == Header.TYPE_LIBRARY) {
+      writeLibraryType();
     }
   }
 


### PR DESCRIPTION
fix build error, when app open aapt custom packageId(--package-id) feature

open custom packageId:
```
aaptOptions {
        additionalParameters '--allow-reserved-package-id','--package-id','0x15'
}
```

stacktrace:
```
com.tencent.mm.androlib.AndrolibException: Could not decode arsc file
  at com.tencent.mm.androlib.res.decoder.ARSCDecoder.write(ARSCDecoder.java:131)
  at com.tencent.mm.androlib.ApkDecoder.decode(ApkDecoder.java:197)
  at com.tencent.mm.resourceproguard.Main.decodeResource(Main.java:114)
  at com.tencent.mm.resourceproguard.Main.resourceProguard(Main.java:98)
  at com.tencent.mm.resourceproguard.Main.resourceProguard(Main.java:84)
  at com.tencent.mm.resourceproguard.cli.CliMain.run(CliMain.java:243)
  at com.tencent.mm.resourceproguard.cli.CliMain.main(CliMain.java:38)
Caused by: java.io.EOFException
  at java.base/java.io.DataInputStream.readFully(DataInputStream.java:202)
  at com.mindprod.ledatastream.LEDataInputStream.readFully(LEDataInputStream.java:180)
```

cause: 
when app open custom packageId, aapt generates more content when generating arsc file than not open custom packageId, so we need read it , and write it to new arsc file


