### PR TITLE
Update white_list.md

### DIFF
--- a/doc/white_list.md
+++ b/doc/white_list.md
@@ -80,6 +80,7 @@ R.string.project_id
 
 ### Firebase Crashlytics
 ```
+"R.string.com.google.firebase.crashlytics.mapping_file_id",
 "R.bool.com.crashlytics.useFirebaseAppId",
 "R.string.com.crashlytics.useFirebaseAppId",
 "R.string.google_app_id",


### PR DESCRIPTION
"R.string.com.google.firebase.crashlytics.mapping_file_id",

使用 Firebase 崩溃统计的时候需要这个，编译期间生成的字符串资源，需要被加入到白名单中，否则会导致应用启动即崩溃